### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,6 +3,9 @@ name: Run Tests and Upload Coverage
 on: 
   push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and collect coverage


### PR DESCRIPTION
Potential fix for [https://github.com/mustafagenc/nitrokit/security/code-scanning/1](https://github.com/mustafagenc/nitrokit/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., checking out code, installing dependencies, running tests, and uploading coverage results), the `contents: read` permission is sufficient. This ensures the workflow can read repository contents without granting unnecessary write access.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
