### PR TITLE
Potential fix for code scanning alert no. 5: Double escaping or unescaping

### DIFF
--- a/src/lib/services/email/providers/resend.ts
+++ b/src/lib/services/email/providers/resend.ts
@@ -52,11 +52,11 @@ export class ResendProvider implements EmailProvider {
             .replace(/<\/h[1-6]>/gi, '\n\n')
             .replace(/<[^>]*>/g, '')
             .replace(/&nbsp;/g, ' ')
-            .replace(/&amp;/g, '&')
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
             .replace(/&quot;/g, '"')
             .replace(/&#39;/g, "'")
+            .replace(/&amp;/g, '&')
             .trim()
             .replace(/\n\s*\n\s*\n/g, '\n\n');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mustafagenc/nitrokit/security/code-scanning/5](https://github.com/mustafagenc/nitrokit/security/code-scanning/5)

To fix the issue, the replacement of `&amp;` with `&` should be moved to the end of the replacement chain. This ensures that other HTML entities like `&lt;` and `&gt;` are correctly decoded before the ampersand itself is unescaped. This approach aligns with the recommendation to unescape the escape character last.

The changes will be made in the `htmlToText` method of the `ResendProvider` class, specifically reordering the `.replace` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
